### PR TITLE
Decrease audio receive buffer

### DIFF
--- a/src/com/limelight/nvstream/av/audio/AudioStream.java
+++ b/src/com/limelight/nvstream/av/audio/AudioStream.java
@@ -16,7 +16,7 @@ public class AudioStream {
 	public static final int RTP_PORT = 48000;
 	public static final int RTCP_PORT = 47999;
 	
-	public static final int RTP_RECV_BUFFER = 64 * 1024;
+	public static final int RTP_RECV_BUFFER = 12 * 100;
 	public static final int MAX_PACKET_SIZE = 100;
 	
 	private DatagramSocket rtp;
@@ -165,6 +165,7 @@ public class AudioStream {
 		};
 		threads.add(t);
 		t.setName("Audio - Receive");
+		t.setPriority(Thread.MAX_PRIORITY);
 		t.start();
 	}
 	


### PR DESCRIPTION
A few months ago I suggested to decrease the audio buffer size #2 Because there was another buffer in between it hadn't much effect. However CAPABILITY_DIRECT_SUBMIT @a41ccad8cf0 has changed things. With a bitrate of 96kbps the current buffer could hold 5 seconds of audio. While there is every 8ms a new sound packet Java can't catch up so I allow a delay of 100ms.